### PR TITLE
Inject server's datetime value to api_port calculation procedure

### DIFF
--- a/api/api-port.js
+++ b/api/api-port.js
@@ -7,6 +7,7 @@ const debug = require('debug')('modcolle:port')
 const querystring = require('querystring')
 const FlashPlayer = require('../util/flash-player')
 const Emitter = require('../util/emitter')
+const serverTime = require('../util/server-time')
 
 const emitter = new Emitter()
 const flashPlayer = new FlashPlayer()
@@ -26,6 +27,7 @@ function calculate({memberId, meta$: {id}}, respond) {
   urlCallbackArgs.id = id
   const flash = flashPlayer.execute('external/Core.swf', {
     memberId,
+    unixtime: serverTime.now('Asia/Tokyo'),
     callbackUrl: escape(`http://127.0.0.1:${PORT}/act?`) + querystring.stringify(urlCallbackArgs)
   })
   flash.stdout.on('data', debug)

--- a/external/as3-import/scripts/Core.as
+++ b/external/as3-import/scripts/Core.as
@@ -11,6 +11,7 @@ package
    {
       private var member:int;
       private var callback:String;
+      private var unixtime:Number;
 
       public function Core()
       {
@@ -19,7 +20,7 @@ package
          trace("Running");
          var port:PortAPI = new PortAPI();
          this.parseFlashvars();
-         api_port = port.__(this.member,port._createKey());
+         api_port = port.__(this.member,this._createKey(port));
          this.sendBackResult(api_port);
       }
 
@@ -29,15 +30,30 @@ package
          if(loaderInfo.loaderURL.match(/^file:/))
          {
             memberStr = stage.loaderInfo.parameters.memberId;
+            this.unixtime = parseInt(stage.loaderInfo.parameters.unixtime);
             this.callback = stage.loaderInfo.parameters.callbackUrl;
          }
          else
          {
             memberStr = root.loaderInfo.parameters.memberId;
+            this.unixtime = parseInt(root.loaderInfo.parameters.unixtime);
             this.callback = root.loaderInfo.parameters.callbackUrl;
          }
          this.callback = unescape(unescape(this.callback));
-         this.member = int(parseInt(memberStr));
+         this.member = parseInt(memberStr);
+      }
+
+      private function _createKey(port:PortAPI) : Object
+      {
+         var key:Object;
+         var _unixtime:Number;
+
+         _unixtime = this.unixtime;
+         key = port._createKey()
+         key.n = function():Number {
+            return key.r(_unixtime / 1000);
+         }
+         return key;
       }
 
       private function sendBackResult(api_port:String) : void

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "debug": "^2.6.3",
+    "moment-timezone": "^0.5.13",
     "seneca": "^3.3.0"
   },
   "devDependencies": {

--- a/util/server-time.js
+++ b/util/server-time.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const moment = require('moment-timezone')
+
+module.exports = {
+  now
+}
+
+function now(timezone = 'Europe/London') {
+  const serverTime = moment(Date.now())
+  return serverTime.tz(timezone).valueOf()
+}


### PR DESCRIPTION
Most common catbomb problems for new players are due to **[incorrect time configuration](http://kancolle.wikia.com/wiki/Tutorial:_Troubleshooting#Is_your_computer_clock_set_on_the_correct_local_time_and_timezone.3F)** causing a lot of frustrations.
If errors occurred frequently, they may leave the game for good without reading troubleshooting section  thoroughly.

By default, Kancolle acquires system time from client's machine.
Meaning that as `api_port` is executed, it will get the current server time.
`modcolle-port` aims to resolve time issues.
Though succeed, it is not flexible enough because I have to configure server time to be in Japan timezone for every deployment in Linux server.
This PR allows time to be passed as URL query parameter and have `port.__()` use the value.
So that `port.__()` will not have to rely on system time, but rather rely on time defined by the `modcolle-port`.

Kancolle expects api_port value to be created from client's current time in Japan timezone (UTC+0900).
If incorrect value are passed, when Kancolle server reverse the value back.
It results in an error.
Then, Kancolle server sends JSON error response back to client resulted in [catbomb image](https://vignette2.wikia.nocookie.net/kancolle/images/6/62/Error1.jpg/revision/latest?cb=20130913212916).

To calculate value of api_port, it requires two values, `memberId` and `system time`.
`PortAPI._createKey()` acquires unix `system time` automatically inside `key.n`.

What `modcolle-port` do is to convert current system time to `Asia/Tokyo` timezone before passing on as flashvars.
Now I don't have to configure server time to be in `Asia/Tokyo` for every deployment.
`modcolle-port` will convert current server time to time japan timezone automatically.