### PR TITLE
Path to Flash Player, Kancolle Core.swf, and server timezone as environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ before_script:
   - travis_retry npm install
 
 script:
-  - PORT=5000 ETIMEOUT=5000 DEBUG=modcolle:* npm run test
+  - PORT=5000 ETIMEOUT=5000 FLASH_PLAYER=bin/flashplayerdebugger KANCOLLE_CORE_SWF=bin/Core.swf TIMEZONE=Asia/Tokyo DEBUG=modcolle:* npm run test

--- a/process.yml
+++ b/process.yml
@@ -7,5 +7,8 @@ apps:
     env:
       PORT: 5000
       ETIMEOUT: 5000
+      KANCOLLE_CORE_SWF: bin/Core.swf
+      FLASH_PLAYER: bin/flashplayerdebugger
+      TIMEZONE: Asia/Tokyo
     env_production:
       NODE_ENV: production

--- a/src/api/api-port.js
+++ b/src/api/api-port.js
@@ -2,6 +2,8 @@
 
 const ETIMEOUT = process.env.ETIMEOUT
 const PORT = process.env.PORT
+const KANCOLLE_CORE_SWF = process.env.KANCOLLE_CORE_SWF
+const TIMEZONE = process.env.TIMEZONE
 
 const debug = require('debug')('modcolle:port')
 const querystring = require('querystring')
@@ -25,9 +27,9 @@ function calculate({memberId, meta$: {id}}, respond) {
 
   const urlCallbackArgs = flashCallback
   urlCallbackArgs.id = id
-  const flash = flashPlayer.execute('bin/Core.swf', {
+  const flash = flashPlayer.execute(KANCOLLE_CORE_SWF, {
     memberId,
-    unixtime: serverTime.now('Asia/Tokyo'),
+    unixtime: serverTime.now(TIMEZONE),
     callbackUrl: escape(`http://127.0.0.1:${PORT}/act?`) + querystring.stringify(urlCallbackArgs)
   })
   flash.stdout.on('data', debug)

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,10 @@ const service = require('./api/')
 const ETIMEOUT = process.env.ETIMEOUT
 const PORT = process.env.PORT
 
+process.env.TIMEZONE = process.env.TIMEZONE || 'Asia/Tokyo'
+process.env.KANCOLLE_CORE_SWF = process.env.KANCOLLE_CORE_SWF || 'bin/Core.swf'
+process.env.FLASH_PLAYER = process.env.FLASH_PLAYER || 'bin/flashplayerdebugger'
+
 service.listen({
   timeout: ETIMEOUT,
   port: PORT,

--- a/src/util/flash-player.js
+++ b/src/util/flash-player.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const ETIMEOUT = process.env.ETIMEOUT
+const FLASH_PLAYER = process.env.FLASH_PLAYER
 
 const debug = require('debug')('modcolle:port')
 const path = require('path')
 const querystring = require('querystring')
 const execFile = require('child_process').execFile
-const defaultPlayer = path.resolve('bin', 'flashplayerdebugger')
+const defaultPlayer = path.resolve(FLASH_PLAYER)
 
 class FlashPlayer {
 


### PR DESCRIPTION
I decided to pass path to Flash Player and Core.swf as environment variables instead of embedded inside the code.
Including timezone too.
These variables can be setup in `process.yml`.

# Path to Flash Player and Core.swf
Path can be absolute or relative.
`path.resolve()` will resolve these paths.

-  If pass as relative, it will be based on where the caller reside
-  If pass as semi-relative eg. `my/path/to`, will be interpreted as `<project_root>/my/path/to`

By default, I set them to `bin/flashplayerdebugger` and `bin/Core.swf` accordingly so that it doesn't conflict with the dockerfile and travis

# Timezone
[IANA Timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) used for shifting current server time into a desired timezone.
In Kancolle, it must be set to Japan timezone `Asia/Tokyo` to create a correct `api_port` value.


