### PR TITLE
Prefer flashplayer over flashplayerdebugger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | te
       $FFDEC_DIR && \
 
     # Install Adobe Flash Player
-    wget -O- https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flash_player_sa_linux_debug.x86_64.tar.gz | tar xvz -C $DEPLOY_DIR/bin/ && \
+    wget -O- https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flash_player_sa_linux.x86_64.tar.gz | tar xvz -C $DEPLOY_DIR/bin/ && \
 
     # Install FFDec
     wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version10.0.0/ffdec_10.0.0.zip -O /tmp/ffdec_10.0.0.zip && \
@@ -97,3 +97,4 @@ RUN chmod +x ./build/docker-entrypoint.sh && \
     npm install --only=production
 
 ENTRYPOINT ["./build/docker-entrypoint.sh"]
+CMD ["production"]

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
 
 service xvfb start
-pm2-docker start process.yml --auto-exit --env $0
+pm2-docker start process.yml --auto-exit --env $1
 exec "$@"

--- a/process.yml
+++ b/process.yml
@@ -12,3 +12,4 @@ apps:
       TIMEZONE: Asia/Tokyo
     env_production:
       NODE_ENV: production
+      FLASH_PLAYER: bin/flashplayer


### PR DESCRIPTION
- Up to 10% less execution time
- Activate only when `--env production` passed to pm2

> Please note that travis still use flashplayerdeubgger because I would like to take a look at swf tracing output for debugging purpose. I have to [config the flash player](https://helpx.adobe.com/flash-player/kb/configure-debugger-version-flash-player.html) first. It is not in high priority so I'll do it later 

Also, I found out that `production` argument passed from `docker-entrypoint.sh` doesn't get passed to `pm2-docker --env`. Expected `--env production` got `--env` because of incorrect parameter number. It should be `$1` not `$0`